### PR TITLE
fix "Create Imaginary Container" workflow

### DIFF
--- a/.github/workflows/imaginary.yml
+++ b/.github/workflows/imaginary.yml
@@ -11,27 +11,63 @@ jobs:
     name: Create Imaginary Container
 
     steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+      - name: Check out the repo
+        uses: actions/checkout@v3
+        with:
+          repository: h2non/imaginary
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Setup Go
+        uses: actions/setup-go@v3
 
-      - name: Check out the repo
+      # https://github.com/WordPress/openverse-api/blob/f0c44d571249a2631eef5a13ea0d56702210daf3/.github/workflows/build_imaginary.yml#L47
+      - name: Update modules # https://github.com/h2non/imaginary/issues/387
         run: |
-          git clone https://github.com/h2non/imaginary.git
+         sed -i 's/bimg v1.1.4/bimg v1.1.9/' go.mod
+         go mod tidy
+      
+      # https://github.com/WordPress/openverse-api/blob/f0c44d571249a2631eef5a13ea0d56702210daf3/.github/workflows/build_imaginary.yml#L53
+      - name: Skip tests # https://github.com/golang/go/issues/29948
+        run: |
+         sed -i 's/RUN go test/# RUN go test/' Dockerfile
+         sed -i 's/RUN golangci/# RUN golangci/' Dockerfile
+
+      - name: Set current date as env variable
+        id: date
+        run: echo "::set-output name=date::$(date +"%Y%m%d")"
+        
+#      - name: Cache Docker layers
+#        uses: actions/cache@v3
+#        with:
+#          path: /tmp/.buildx-cache
+#          key: buildx-${{ secrets.CACHE_ID }}-${{ github.ref_name }}-${{ github.sha }}
+#          restore-keys: |
+#            buildx-${{ secrets.CACHE_ID }}-${{ github.ref_name }}-
 
       - name: Build and push image
-        run: |
-          cd imaginary
-
-          # Build the image
-          DATE="$(date +"%Y%m%d")"
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker buildx create --name builder --driver docker-container --use
-          docker buildx inspect --bootstrap
-          docker buildx build --platform=linux/arm64,linux/amd64 . --file Dockerfile --tag nextcloud/imaginary --push --label "${DATE}"
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64 #,linux/amd64/v2,linux/amd64/v3,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          push: true
+          tags: nextcloud/imaginary:${{ steps.date.outputs.date }}
+          labels: ${{ steps.date.outputs.date }}
+#          cache-from: type=local,src=/tmp/.buildx-cache
+#          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Signed-off-by: Zoey <zoey@z0ey.de>
I've got with a similar file (push set to false, login disabled and caching enabled) a [successful run](https://github.com/Z0ey2022/test/actions/runs/2882707510)
I've added the patches of [this workflow file](https://github.com/WordPress/openverse-api/blob/main/.github/workflows/build_imaginary.yml) - both patches were needed to make it run