### PR TITLE
Switch from ::set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/imaginary.yml
+++ b/.github/workflows/imaginary.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Set current date as env variable
         id: date
-        run: echo "::set-output name=date::$(date +"%Y%m%d")"
+        run: echo "date=$(date +"%Y%m%d")" >> $GITHUB_OUTPUT
         
 #      - name: Cache Docker layers
 #        uses: actions/cache@v3

--- a/.github/workflows/promote-to-latest.yml
+++ b/.github/workflows/promote-to-latest.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Set current date as env variable
         id: date
-        run: echo "::set-output name=date::$(date +"%Y%m%d_%H%M%S")"
+        run: echo "date=$(date +"%Y%m%d_%H%M%S")" >> $GITHUB_OUTPUT
 
   promote_to_latest:
     needs: get_time


### PR DESCRIPTION
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands
Signed-off-by: Zoey <zoey@z0ey.de>