### PR TITLE
Build multiarch

### DIFF
--- a/.github/workflows/promote-to-beta.yml
+++ b/.github/workflows/promote-to-beta.yml
@@ -48,7 +48,7 @@ jobs:
             # arm64
             docker buildx imagetools create --tag nextcloud/$AIO_NAME\:beta-arm64 nextcloud/$AIO_NAME\:develop-arm64
             
-        elif [ "$AIO_NAME" == "aio-clamav" ]; then
+        else
             # amd64
             docker buildx imagetools create --tag nextcloud/$AIO_NAME\:beta nextcloud/$AIO_NAME\:develop
         fi

--- a/.github/workflows/promote-to-beta.yml
+++ b/.github/workflows/promote-to-beta.yml
@@ -33,18 +33,22 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Promote images from develop to beta
+        
+    - name: Promote images from develop to beta (create multiarch)
       run: |
         set -x
         AIO_NAME=${{ matrix.name }}
         set +x
-        # x64
-        docker pull nextcloud/$AIO_NAME\:develop
-        docker tag nextcloud/$AIO_NAME\:develop nextcloud/$AIO_NAME\:beta
-        docker push nextcloud/$AIO_NAME\:beta
+        
         if [ "$AIO_NAME" != "aio-clamav" ]; then
-          # arm64 
-          docker pull nextcloud/$AIO_NAME\:develop-arm64
-          docker tag nextcloud/$AIO_NAME\:develop-arm64 nextcloud/$AIO_NAME\:beta-arm64
-          docker push nextcloud/$AIO_NAME\:beta-arm64
+            # create multiarch image
+            docker manifest create nextcloud/$AIO_NAME\:beta -a nextcloud/$AIO_NAME\:develop -a nextcloud/$AIO_NAME\:develop-arm64
+            docker manifest push nextcloud/$AIO_NAME\:beta
+            
+            # arm64
+            docker buildx imagetools create --tag nextcloud/$AIO_NAME\:beta-arm64 nextcloud/$AIO_NAME\:develop-arm64
+            
+        elif [ "$AIO_NAME" == "aio-clamav" ]; then
+            # amd64
+            docker buildx imagetools create --tag nextcloud/$AIO_NAME\:beta nextcloud/$AIO_NAME\:develop
         fi

--- a/.github/workflows/promote-to-latest.yml
+++ b/.github/workflows/promote-to-latest.yml
@@ -43,6 +43,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+        
     - name: Promote images from beta to latest
       run: |
         set -x
@@ -52,35 +53,30 @@ jobs:
           exit 1
         fi
         set +x
-        # x64
-        docker pull nextcloud/$AIO_NAME\:beta
-        docker tag nextcloud/$AIO_NAME\:beta nextcloud/$AIO_NAME\:latest
-        docker push nextcloud/$AIO_NAME\:latest
-        docker tag nextcloud/$AIO_NAME\:beta nextcloud/$AIO_NAME\:"$DATE"-latest
-        docker push nextcloud/$AIO_NAME\:"$DATE"-latest
-        if [ "$AIO_NAME" = "aio-nextcloud" ]; then
-          set -x
-          PHP_VERSION="$(docker inspect nextcloud/aio-nextcloud:beta | grep PHP_VERSION | grep -oP '[0-8.]+' | sed 's|\.[0-9]\+$||')"
-          if [ -n "$PHP_VERSION" ]; then
-            docker tag nextcloud/aio-nextcloud\:beta nextcloud/aio-nextcloud\:php"$PHP_VERSION"-latest
-            docker push nextcloud/aio-nextcloud\:php"$PHP_VERSION"-latest
-          fi
-          set +x
-        fi
+        
+        # multiarch
+        docker buildx imagetools create --tag nextcloud/$AIO_NAME\:latest nextcloud/$AIO_NAME\:beta
+        docker buildx imagetools create --tag nextcloud/$AIO_NAME\:"$DATE"-latest nextcloud/$AIO_NAME\:beta
+        
+        # arm64
         if [ "$AIO_NAME" != "aio-clamav" ]; then
-          # arm64 
-          docker pull nextcloud/$AIO_NAME\:beta-arm64
-          docker tag nextcloud/$AIO_NAME\:beta-arm64 nextcloud/$AIO_NAME\:latest-arm64
-          docker push nextcloud/$AIO_NAME\:latest-arm64
-          docker tag nextcloud/$AIO_NAME\:beta-arm64 nextcloud/$AIO_NAME\:"$DATE"-latest-arm64
-          docker push nextcloud/$AIO_NAME\:"$DATE"-latest-arm64
-          if [ "$AIO_NAME" = "aio-nextcloud" ]; then
-          set -x
-          PHP_VERSION="$(docker inspect nextcloud/aio-nextcloud:beta-arm64 | grep PHP_VERSION | grep -oP '[0-8.]+' | sed 's|\.[0-9]\+$||')"
-          if [ -n "$PHP_VERSION" ]; then
-            docker tag nextcloud/aio-nextcloud\:beta-arm64 nextcloud/aio-nextcloud\:php"$PHP_VERSION"-latest-arm64
-            docker push nextcloud/aio-nextcloud\:php"$PHP_VERSION"-latest-arm64
-          fi
-          set +x
+        docker buildx imagetools create --tag nextcloud/$AIO_NAME\:latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
+        docker buildx imagetools create --tag nextcloud/$AIO_NAME\:"$DATE"-latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
         fi
+        
+        if [ "$AIO_NAME" == "aio-nextcloud" ]; then
+            set -x
+            docker pull nextcloud/$AIO_NAME\:beta
+            PHP_VERSION="$(docker inspect nextcloud/$AIO_NAME\:beta | grep PHP_VERSION | grep -oP '[0-8.]+' | sed 's|\.[0-9]\+$||')"
+            docker image remove nextcloud/$AIO_NAME\:beta
+            if [ -n "$PHP_VERSION" ]; then
+                # multiarch
+                docker buildx imagetools create --tag nextcloud/$AIO_NAME\:php"$PHP_VERSION"-latest nextcloud/$AIO_NAME\:beta
+                
+                # arm64
+                if [ "$AIO_NAME" != "aio-clamav" ]; then
+                    docker buildx imagetools create --tag nextcloud/$AIO_NAME\:php"$PHP_VERSION"-latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
+                fi
+            fi
+            set +x
         fi

--- a/.github/workflows/promote-to-latest.yml
+++ b/.github/workflows/promote-to-latest.yml
@@ -68,7 +68,7 @@ jobs:
             set -x
             docker pull nextcloud/$AIO_NAME\:beta
             PHP_VERSION="$(docker inspect nextcloud/$AIO_NAME\:beta | grep PHP_VERSION | grep -oP '[0-8.]+' | sed 's|\.[0-9]\+$||')"
-            docker image remove nextcloud/$AIO_NAME\:beta
+            docker image remove --force nextcloud/$AIO_NAME\:beta
             if [ -n "$PHP_VERSION" ]; then
                 # multiarch
                 docker buildx imagetools create --tag nextcloud/$AIO_NAME\:php"$PHP_VERSION"-latest nextcloud/$AIO_NAME\:beta

--- a/.github/workflows/promote-to-latest.yml
+++ b/.github/workflows/promote-to-latest.yml
@@ -60,8 +60,8 @@ jobs:
         
         # arm64
         if [ "$AIO_NAME" != "aio-clamav" ]; then
-        docker buildx imagetools create --tag nextcloud/$AIO_NAME\:latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
-        docker buildx imagetools create --tag nextcloud/$AIO_NAME\:"$DATE"-latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
+            docker buildx imagetools create --tag nextcloud/$AIO_NAME\:latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
+            docker buildx imagetools create --tag nextcloud/$AIO_NAME\:"$DATE"-latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
         fi
         
         if [ "$AIO_NAME" == "aio-nextcloud" ]; then

--- a/.github/workflows/promote-to-latest.yml
+++ b/.github/workflows/promote-to-latest.yml
@@ -72,11 +72,8 @@ jobs:
             if [ -n "$PHP_VERSION" ]; then
                 # multiarch
                 docker buildx imagetools create --tag nextcloud/$AIO_NAME\:php"$PHP_VERSION"-latest nextcloud/$AIO_NAME\:beta
-                
                 # arm64
-                if [ "$AIO_NAME" != "aio-clamav" ]; then
-                    docker buildx imagetools create --tag nextcloud/$AIO_NAME\:php"$PHP_VERSION"-latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
-                fi
+                docker buildx imagetools create --tag nextcloud/$AIO_NAME\:php"$PHP_VERSION"-latest-arm64 nextcloud/$AIO_NAME\:beta-arm64
             fi
             set +x
         fi


### PR DESCRIPTION
Signed-off-by: Zoey <zoey@z0ey.de>

Based on: https://github.com/nextcloud/all-in-one/discussions/490#discussioncomment-4706290
Should work, but not tested

I don't know, but maybe AIO needs support for the latest-amd64, beta-amd64 etc tags? (Internally)

It first created the ":develop" tag, after the "develop-arm64" tag was built, but the "develop-amd64" tag is available earlier