### PR TITLE
update Github Actions to use commit hashes for 3rd party actions instead of version tags

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2 
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build docker image and push to dockerhub
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6
         with:
           context: ${{ matrix.container.context }}
           platforms: linux/amd64
@@ -79,12 +79,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2 
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build docker image and push to dockerhub
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6
         with:
           context: ${{ matrix.container.context }}
           platforms: linux/arm64

--- a/.github/workflows/promote-single-container.yml
+++ b/.github/workflows/promote-single-container.yml
@@ -16,7 +16,7 @@ jobs:
     name: Promote ${{ github.event.inputs.imageName }} to ${{ github.event.inputs.targetTag }}
     steps:
     - name: Login to DockerHub
-      uses: docker/login-action@v2 
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/promote-to-beta.yml
+++ b/.github/workflows/promote-to-beta.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Login to DockerHub
-      uses: docker/login-action@v2 
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/promote-to-latest.yml
+++ b/.github/workflows/promote-to-latest.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Login to DockerHub
-      uses: docker/login-action@v2 
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -24,6 +24,6 @@ jobs:
         git add -A
         git commit -m "Repo-sync" || echo "Nothing to update"
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run Shellcheck
-      uses: ludeeus/action-shellcheck@2.0.0
+      uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
       with:
         check_together: 'yes'
       env:


### PR DESCRIPTION
- [x] Wait for AIO v10.8.0 to become stable